### PR TITLE
Test format graphql query to bytecode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,4 +19,4 @@ jobs:
         go-version: 1.16
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [1.16, 1.15, 1.14]
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go }}
 
     - name: Test
       run: go test -v ./...

--- a/bytecode/README.md
+++ b/bytecode/README.md
@@ -1,0 +1,7 @@
+# Bytecode query parser
+
+This is a test to improve the query parsing and resolve speed.
+
+## How to understand it?
+
+Currently the best way to understand the bytecode is to read the `bytecode_test.go` and look at the `bytecode_instructions.go`

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -371,6 +371,8 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 				}
 
 				ctx.instructionNewFragmentSpread(isInline)
+				directivesCountLocation := len(ctx.res) - 1
+
 				empyt, criticalErr := ctx.parseAndWriteName()
 				if criticalErr {
 					return criticalErr
@@ -386,6 +388,15 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 					} else {
 						return ctx.err(`expected fragment name but got char: "` + string(c) + `"`)
 					}
+				}
+
+				if c == '@' {
+					amount, criticalErr := ctx.parseDirectives()
+					ctx.res[directivesCountLocation] = amount
+					if criticalErr {
+						return criticalErr
+					}
+					c = ctx.currentC()
 				}
 
 				if isInline {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -303,6 +303,7 @@ func (ctx *parserCtx) parseAssignmentSet(closure byte) bool {
 	}
 	if c == closure {
 		ctx.instructionEnd()
+		ctx.charNr++
 		return false
 	}
 
@@ -325,6 +326,7 @@ func (ctx *parserCtx) parseAssignmentSet(closure byte) bool {
 		}
 		if c == closure {
 			ctx.instructionEnd()
+			ctx.charNr++
 			return false
 		}
 	}

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -44,6 +44,7 @@ func (ctx *parserCtx) parseOperatorOrFragment() (stop bool) {
 		} else {
 			ctx.instructionNewOperation(operatorSubscription)
 		}
+		hasArgsFlagLocation := len(ctx.res) - 1
 
 		// Parse operation name
 		_, eof = ctx.mightIgnoreNextTokens()
@@ -60,6 +61,7 @@ func (ctx *parserCtx) parseOperatorOrFragment() (stop bool) {
 			return ctx.unexpectedEOF()
 		}
 		if c == '(' {
+			ctx.res[hasArgsFlagLocation] = 't'
 			ctx.charNr++
 			criticalErr := ctx.parseOperatorArguments()
 			if criticalErr {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -167,7 +167,7 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 					if !eof && (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_') {
 						// This is not an inline fragment, there are name chars behind the "on" for example: "online" (starts with on)
 						// Revert the changes made by the match
-						ctx.res = ctx.res[:len(ctx.res)-2]
+						ctx.charNr -= 2
 						isInline = false
 					} else {
 						_, eof := ctx.mightIgnoreNextTokens()
@@ -196,6 +196,7 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 				}
 
 				if isInline {
+					// parse inline fragment selection set
 					if c != '{' {
 						return ctx.err(`expected selection set open ("{") on inline fragment but got "` + string(c) + `"`)
 					}

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -389,8 +389,45 @@ func (ctx *parserCtx) parseInputValue() bool {
 	}
 
 	if c == '[' {
-		// TODO parse list
-		return ctx.err("value kind unsupported")
+		ctx.charNr++
+		ctx.instructionNewValueList()
+
+		c, eof := ctx.mightIgnoreNextTokens()
+		if eof {
+			return ctx.unexpectedEOF()
+		}
+
+		if c == ']' {
+			ctx.charNr++
+			ctx.instructionEnd()
+			return false
+		}
+
+		for {
+			criticalErr := ctx.parseInputValue()
+			if criticalErr {
+				return criticalErr
+			}
+
+			c, eof := ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
+
+			if c == ',' {
+				ctx.charNr++
+				c, eof = ctx.mightIgnoreNextTokens()
+				if eof {
+					return ctx.unexpectedEOF()
+				}
+			}
+
+			if c == ']' {
+				ctx.charNr++
+				ctx.instructionEnd()
+				return false
+			}
+		}
 	}
 
 	if c == '{' {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -254,6 +254,7 @@ func (ctx *parserCtx) parseDirectives() (directivesAmount uint8, criticalErr boo
 			return directivesAmount, ctx.err(`expected directive name but got char "` + string(ctx.currentC()) + `"`)
 		}
 
+		// parse arguments
 		c, eof = ctx.mightIgnoreNextTokens()
 		if eof {
 			return directivesAmount, ctx.unexpectedEOF()
@@ -261,10 +262,12 @@ func (ctx *parserCtx) parseDirectives() (directivesAmount uint8, criticalErr boo
 		if c != '(' {
 			continue
 		}
-
 		ctx.res[hasArgsFlag] = 't'
-		// TODO, support this
-		return directivesAmount, ctx.err(`directive arguments are currently unsupported`)
+		ctx.charNr++
+		criticalErr = ctx.parseAssignmentSet(')')
+		if criticalErr {
+			return directivesAmount, criticalErr
+		}
 	}
 }
 

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -15,19 +15,22 @@ func (ctx *parserCtx) parseQueryToBytecode() {
 	*ctx = parserCtx{
 		res:    ctx.res[:0],
 		query:  ctx.query,
-		charNr: 0,
 		errors: ctx.errors[:0],
 	}
 
-	ctx.parseOperatorOrFragment()
+	for {
+		if ctx.parseOperatorOrFragment() {
+			return
+		}
+	}
 }
 
 // - http://spec.graphql.org/June2018/#sec-Language.Operations
 // - http://spec.graphql.org/June2018/#FragmentDefinition
-func (ctx *parserCtx) parseOperatorOrFragment() bool {
+func (ctx *parserCtx) parseOperatorOrFragment() (stop bool) {
 	c, eof := ctx.mightIgnoreNextTokens()
 	if eof {
-		return false
+		return true
 	}
 
 	if c == '{' {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -150,6 +150,7 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 		if criticalError {
 			return criticalError
 		}
+
 		if empty {
 			// Revert changes from ctx.instructionNewField()
 			ctx.res = ctx.res[:len(ctx.res)-2]
@@ -223,6 +224,29 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 		c, eof := ctx.mightIgnoreNextTokens()
 		if eof {
 			return ctx.unexpectedEOF()
+		}
+
+		ctx.res = append(ctx.res, 0)
+
+		if c == ':' {
+			ctx.charNr++
+			_, eof = ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
+
+			empty, criticalErr := ctx.parseAndWriteName()
+			if criticalErr {
+				return criticalErr
+			}
+			if empty {
+				return ctx.err(`unexpected character, expected nvalid name char but got "` + string(c) + `"`)
+			}
+
+			c, eof = ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
 		}
 
 		if c == '{' {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -318,9 +318,20 @@ func (ctx *parserCtx) parseAssignmentSet(closure byte) bool {
 			return ctx.err(`expected name character but got: "` + string(ctx.currentC()) + `"`)
 		}
 
-		// TODO support the actual value :^)
+		c, eof = ctx.mightIgnoreNextTokens()
+		if eof {
+			return ctx.unexpectedEOF()
+		}
+		if c != ':' {
+			return ctx.err(`expected ":" but got "` + string(c) + `"`)
+		}
 
-		c, eof := ctx.mightIgnoreNextTokens()
+		criticalErr = ctx.parseInputValue()
+		if criticalErr {
+			return criticalErr
+		}
+
+		c, eof = ctx.mightIgnoreNextTokens()
 		if eof {
 			return ctx.unexpectedEOF()
 		}
@@ -330,6 +341,52 @@ func (ctx *parserCtx) parseAssignmentSet(closure byte) bool {
 			return false
 		}
 	}
+}
+
+func (ctx *parserCtx) parseInputValue() bool {
+	c, eof := ctx.mightIgnoreNextTokens()
+	if eof {
+		return ctx.unexpectedEOF()
+	}
+
+	if c == 't' || c == 'f' {
+		// TODO parse boolean
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == '$' {
+		// TODO parse variable
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == '-' || c == '.' || (c >= '0' && c <= '9') {
+		// TODO parse number or float
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == '"' {
+		// TODO parse string
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == '[' {
+		// TODO parse list
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == '{' {
+		// TODO parse object
+		return ctx.err("value kind unsupported")
+	}
+
+	if c == 'n' {
+		// TODO value might be "null"
+		return ctx.err("value kind unsupported")
+	}
+
+	// TODO parse enum
+
+	return ctx.err("value kind unsupported")
 }
 
 //

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -344,6 +344,7 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 
 	for {
 		ctx.instructionNewField()
+		directivesCountLocation := len(ctx.res) - 1
 
 		empty, criticalError := ctx.parseAndWriteName()
 		if criticalError {
@@ -352,7 +353,7 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 
 		if empty {
 			// Revert changes from ctx.instructionNewField()
-			ctx.res = ctx.res[:len(ctx.res)-2]
+			ctx.res = ctx.res[:len(ctx.res)-3]
 
 			if ctx.matches("...") == 0 {
 				// Is pointer to fragment or inline fragment
@@ -446,6 +447,15 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 			if eof {
 				return ctx.unexpectedEOF()
 			}
+		}
+
+		if c == '@' {
+			amount, criticalErr := ctx.parseDirectives()
+			ctx.res[directivesCountLocation] = amount
+			if criticalErr {
+				return criticalErr
+			}
+			c = ctx.currentC()
 		}
 
 		if c == '(' {

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -106,14 +106,28 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 			return ctx.unexpectedEOF()
 		}
 		if empty {
-			return ctx.err(`expected field name character but got "` + string(c) + `"`)
+			return ctx.err(`unexpected character, expected valid name or selection closure but got: "` + string(c) + `"`)
+		}
+		if c == '{' {
+			ctx.charNr++
+
+			criticalErr := ctx.parseSelectionSet()
+			if criticalErr {
+				return criticalErr
+			}
+
+			ctx.charNr++
+
+			c, eof = ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
 		}
 
 		ctx.instructionEnd()
+
 		if c == '}' {
 			return false
-		} else {
-			return ctx.err(`unexpected character in parsing field "` + string(c) + `"`)
 		}
 	}
 }

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -494,6 +494,7 @@ func (ctx *parserCtx) parseNumberInputValue() bool {
 		}
 	}
 
+	// Parse the numbers behind the comma (the 456 of +123.456e78)
 	if c == '.' {
 		ctx.res[valueTypeAt] = valueFloat
 		ctx.res = append(ctx.res, '.')
@@ -522,6 +523,7 @@ func (ctx *parserCtx) parseNumberInputValue() bool {
 		}
 	}
 
+	// Parse the exponent (the 78 of +123.456e78)
 	if c == 'e' || c == 'E' {
 		ctx.res[valueTypeAt] = valueFloat
 		ctx.res = append(ctx.res, 'E')

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -343,8 +343,16 @@ func (ctx *parserCtx) parseInputValue() bool {
 	}
 
 	if c == '$' {
-		// TODO parse variable
-		return ctx.err("value kind unsupported")
+		ctx.charNr++
+		ctx.instructionNewValueVariable()
+		empty, criticalErr := ctx.parseAndWriteName()
+		if criticalErr {
+			return criticalErr
+		}
+		if empty {
+			return ctx.err(`variable input should have a name, got character: "` + string(ctx.currentC()) + `"`)
+		}
+		return false
 	}
 
 	if c == '-' || c == '.' || (c >= '0' && c <= '9') {
@@ -377,9 +385,15 @@ func (ctx *parserCtx) parseInputValue() bool {
 		return false
 	}
 
-	// TODO parse enum
-
-	return ctx.err(`value kind unsupported, char: "` + string(c) + `"`)
+	ctx.instructionNewValueEnum()
+	empty, criticalErr := ctx.parseAndWriteName()
+	if criticalErr {
+		return criticalErr
+	}
+	if empty {
+		return ctx.err(`unknown value kind, got character: "` + string(ctx.currentC()) + `"`)
+	}
+	return false
 }
 
 //

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -1,0 +1,216 @@
+package graphql
+
+import (
+	"errors"
+)
+
+type parserCtx struct {
+	res    []byte
+	query  []byte
+	charNr int
+	errors []error
+}
+
+func (ctx *parserCtx) parseQueryToBytecode() {
+	*ctx = parserCtx{
+		res:    ctx.res[:0],
+		query:  ctx.query,
+		charNr: 0,
+		errors: ctx.errors[:0],
+	}
+
+	ctx.parseOperatorOrFragment()
+}
+
+func (ctx *parserCtx) parseOperatorOrFragment() {
+	c := ctx.mightIgnoreNextTokens()
+
+	if c == '{' {
+
+	}
+}
+
+//
+// ITERATOR HELPERS
+//
+
+func (ctx *parserCtx) checkC(nr int) (res byte, end bool) {
+	if ctx.eof(nr) {
+		return 0, true
+	}
+	return ctx.c(nr), false
+}
+
+func (ctx *parserCtx) c(nr int) byte {
+	return ctx.query[nr]
+}
+
+func (ctx *parserCtx) eof(nr int) bool {
+	return nr >= len(ctx.query)
+}
+
+func (ctx *parserCtx) currentC() byte {
+	return ctx.c(ctx.charNr)
+}
+
+func (ctx *parserCtx) mightIgnoreNextTokens() (nextC byte, eof bool) {
+	for {
+		c, eof := ctx.checkC(ctx.charNr)
+		if eof {
+			return 0, true
+		}
+
+		isIgnoredChar := ctx.isIgnoredToken(c)
+		if !isIgnoredChar {
+			return c, false
+		}
+
+		ctx.charNr++
+	}
+}
+
+// https://spec.graphql.org/June2018/#sec-Source-Text.Ignored-Tokens
+func (ctx *parserCtx) isIgnoredToken(c byte) bool {
+	// TODO this doesn't support unicode bomb
+	return c == ' ' || c == '\t' || ctx.isLineTerminator() || ctx.isComment(true) || c == 0
+}
+
+// https://spec.graphql.org/June2018/#LineTerminator
+func (ctx *parserCtx) isLineTerminator() bool {
+	c := ctx.currentC()
+	if c == '\n' {
+		return true
+	}
+	if c == '\r' {
+		next, _ := ctx.checkC(ctx.charNr + 1)
+		if next == '\n' {
+			ctx.charNr++
+		}
+		return true
+	}
+	return false
+}
+
+// https://spec.graphql.org/June2018/#Comment
+func (ctx *parserCtx) isComment(parseComment bool) bool {
+	if ctx.currentC() == '#' {
+		if parseComment {
+			ctx.parseComment()
+		}
+		return true
+	}
+	return false
+}
+
+func (ctx *parserCtx) parseComment() {
+	for {
+		if ctx.eof(ctx.charNr) {
+			return
+		}
+		if ctx.isLineTerminator() {
+			return
+		}
+		ctx.charNr++
+	}
+}
+
+func (ctx *parserCtx) matches(oneOf ...string) int {
+	startIdx := ctx.charNr
+
+	lastChecked := ""
+	for {
+		c, eof := ctx.checkC(ctx.charNr)
+		if eof {
+			ctx.charNr = startIdx
+			return -1
+		}
+		offset := ctx.charNr - startIdx
+
+		for idx, key := range oneOf {
+			keyLen := len(key)
+			if offset < keyLen {
+				if key[offset] != c {
+					// Nullify value so we won't check it again
+					oneOf[idx] = ""
+				} else if keyLen == offset+1 {
+					ctx.charNr++
+					return idx
+				} else {
+					lastChecked = key
+				}
+			}
+		}
+
+		if lastChecked == "" {
+			ctx.charNr = startIdx
+			return -1
+		}
+
+		ctx.charNr++
+	}
+}
+
+type ErrorWLocation struct {
+	err    error
+	line   uint
+	column uint
+}
+
+func (e ErrorWLocation) Error() string {
+	return e.err.Error()
+}
+
+func (ctx *parserCtx) err(err string) bool {
+	line := uint(1)
+	column := uint(0)
+	for idx, char := range ctx.query {
+		if idx == ctx.charNr {
+			break
+		}
+
+		switch char {
+		case '\n':
+			if column == 0 && idx > 0 && ctx.query[idx-1] == '\r' {
+				// don't count \r\n as 2 lines
+				continue
+			}
+			line++
+			column = 0
+		case '\r':
+			line++
+			column = 0
+		default:
+			column++
+		}
+	}
+
+	ctx.errors = append(ctx.errors, ErrorWLocation{
+		errors.New(err),
+		line,
+		uint(column),
+	})
+	return true
+}
+
+func (ctx *parserCtx) unexpectedEOF() bool {
+	return ctx.err("unexpected EOF")
+}
+
+func (ctx *parserCtx) parseAndWriteName() (notEmpty bool, criticalError bool) {
+	written := false
+	for {
+		c, eof := ctx.checkC(ctx.charNr)
+		if eof {
+			return written, ctx.unexpectedEOF()
+		}
+
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || (written && c >= '0' && c <= '9') {
+			ctx.res = append(ctx.res, c)
+			ctx.charNr++
+			written = true
+			continue
+		}
+
+		return written, false
+	}
+}

--- a/bytecode/bytecode.go
+++ b/bytecode/bytecode.go
@@ -202,6 +202,14 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 					}
 				}
 
+				if c == ',' {
+					ctx.charNr++
+					c, eof = ctx.mightIgnoreNextTokens()
+					if eof {
+						return ctx.unexpectedEOF()
+					}
+				}
+
 				if c == '}' {
 					ctx.charNr++
 					return false
@@ -277,6 +285,14 @@ func (ctx *parserCtx) parseSelectionSet() bool {
 
 		ctx.instructionEnd()
 
+		if c == ',' {
+			ctx.charNr++
+			c, eof = ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
+		}
+
 		if c == '}' {
 			ctx.charNr++
 			return false
@@ -327,6 +343,13 @@ func (ctx *parserCtx) parseAssignmentSet(closure byte) bool {
 		c, eof = ctx.mightIgnoreNextTokens()
 		if eof {
 			return ctx.unexpectedEOF()
+		}
+		if c == ',' {
+			ctx.charNr++
+			c, eof = ctx.mightIgnoreNextTokens()
+			if eof {
+				return ctx.unexpectedEOF()
+			}
 		}
 		if c == closure {
 			ctx.instructionEnd()

--- a/bytecode/bytecode_benchmark_test.go
+++ b/bytecode/bytecode_benchmark_test.go
@@ -1,0 +1,123 @@
+package graphql
+
+import (
+	"testing"
+)
+
+func BenchmarkQueryParser(b *testing.B) {
+	ctx := parserCtx{
+		res:    make([]byte, 2048),
+		query:  []byte(schemaQuery),
+		charNr: 0,
+		errors: []error{},
+	}
+
+	for i := 0; i < b.N; i++ {
+		ctx.parseQueryToBytecode()
+		if len(ctx.errors) > 0 {
+			panic(ctx.errors[len(ctx.errors)-1])
+		}
+	}
+}
+
+var schemaQuery = `
+query IntrospectionQuery {
+	__schema {
+		queryType {
+			name
+		}
+		mutationType {
+			name
+		}
+		subscriptionType {
+			name
+		}
+		types {
+			...FullType
+		}
+		directives {
+			name
+			description
+			locations
+			args {
+				...InputValue
+			}
+		}
+	}
+}
+
+fragment FullType on __Type {
+	kind
+	name
+	description
+	fields(includeDeprecated: true) {
+		name
+		description
+		args {
+			...InputValue
+		}
+		type {
+			...TypeRef
+		}
+		isDeprecated
+		deprecationReason
+	}
+	inputFields {
+		...InputValue
+	}
+	interfaces {
+		...TypeRef
+	}
+	enumValues(includeDeprecated: true) {
+		name
+		description
+		isDeprecated
+		deprecationReason
+	}
+	possibleTypes {
+		...TypeRef
+	}
+}
+
+fragment InputValue on __InputValue {
+	name
+	description
+	type {
+		...TypeRef
+	}
+	defaultValue
+}
+
+fragment TypeRef on __Type {
+	kind
+	name
+	ofType {
+		kind
+		name
+		ofType {
+			kind
+			name
+			ofType {
+				kind
+				name
+				ofType {
+					kind
+					name
+					ofType {
+						kind
+						name
+						ofType {
+							kind
+							name
+							ofType {
+								kind
+								name
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+`

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -6,6 +6,7 @@ const (
 	actionEnd      action = 'e'
 	actionOperator action = 'o'
 	actionField    action = 'f'
+	actionFragment action = 'F'
 )
 
 type operatorKind = byte
@@ -22,7 +23,7 @@ const (
 // ^- Kind
 //
 // writes:
-// i [actionNewOperator] [kind]
+// 0 [actionNewOperator] [kind]
 //
 // additional append:
 // [name...]
@@ -34,11 +35,27 @@ func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
 
 // represends:
 //
+// fragment InputValue on __InputValue {
+//          ^- Name       ^- Type Name
+//
+// writes:
+// 0 [actionFragment]
+//
+// additional required append:
+// [Name] 0 [Type Name]
+func (ctx *parserCtx) instructionNewFragment() int {
+	res := len(ctx.res)
+	ctx.res = append(ctx.res, 0, actionFragment)
+	return res
+}
+
+// represends:
+//
 // query { a }
 //         ^
 //
 // writes:
-// i [actionField]
+// 0 [actionField]
 func (ctx *parserCtx) instructionNewField() {
 	ctx.res = append(ctx.res, 0, actionField)
 }
@@ -55,7 +72,7 @@ func (ctx *parserCtx) instructionNewField() {
 //          ^- End
 //
 // writes:
-// i [actionEndClosure]
+// 0 [actionEndClosure]
 func (ctx *parserCtx) instructionEnd() {
 	ctx.res = append(ctx.res, 0, actionEnd)
 }

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -15,7 +15,7 @@ const (
 type valueKind = byte
 
 const (
-	valueVariable valueKind = 'v'
+	valueVariable valueKind = '$'
 	valueInt      valueKind = 'i'
 	valueFloat    valueKind = 'f'
 	valueString   valueKind = 's'
@@ -128,6 +128,14 @@ func (ctx *parserCtx) instructionNewValueBoolean(val bool) {
 
 func (ctx *parserCtx) instructionNewValueNull() {
 	ctx.res = append(ctx.res, 0, actionValue, valueNull)
+}
+
+func (ctx *parserCtx) instructionNewValueEnum() {
+	ctx.res = append(ctx.res, 0, actionValue, valueEnum)
+}
+
+func (ctx *parserCtx) instructionNewValueVariable() {
+	ctx.res = append(ctx.res, 0, actionValue, valueVariable)
 }
 
 // represends:

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -6,6 +6,7 @@ const (
 	actionEnd      action = 'e'
 	actionOperator action = 'o'
 	actionField    action = 'f'
+	actionSpread   action = 's'
 	actionFragment action = 'F'
 )
 
@@ -58,6 +59,28 @@ func (ctx *parserCtx) instructionNewFragment() int {
 // 0 [actionField]
 func (ctx *parserCtx) instructionNewField() {
 	ctx.res = append(ctx.res, 0, actionField)
+}
+
+// represends:
+//
+// {
+//   ...Foo
+//   ^- Fragment spread in selector
+//   ... on Banana {}
+//   ^- Also a fragment spread
+// }
+//
+// writes:
+// 0 [actionSpread] [t/f (t = inline fragment, f = pointer to fragment)]
+//
+// additional required append:
+// [Typename or Fragment Name]
+func (ctx *parserCtx) instructionNewFragmentSpread(isInline bool) {
+	if isInline {
+		ctx.res = append(ctx.res, 0, actionSpread, 't')
+	} else {
+		ctx.res = append(ctx.res, 0, actionSpread, 'f')
+	}
 }
 
 // represends:

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -1,0 +1,44 @@
+package graphql
+
+type action = byte
+
+const (
+	actionEndClosure action = iota + 1
+	actionNewOperator
+)
+
+type operatorKind = byte
+
+const (
+	operatorQuery operatorKind = iota + 1
+	operatorMutation
+	operatorSubscription
+)
+
+// represends:
+//
+// query {
+// ^- Kind
+//
+// writes:
+// 0 [actionNewOperator] [kind]
+//
+// additional append:
+// [name...]
+func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
+	res := len(ctx.res)
+	ctx.res = append(ctx.res, 0, actionNewOperator, kind)
+	return res
+}
+
+// represends:
+//
+// query { }
+//         ^- Closure
+//
+// query { a { } }
+//             ^- Closure
+//
+func (ctx *parserCtx) instructionEndClosure() {
+	ctx.res = append(ctx.res, 0, actionEndClosure)
+}

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -180,6 +180,10 @@ func (ctx *parserCtx) instructionNewValueInt() {
 	ctx.res = append(ctx.res, 0, actionValue, valueInt)
 }
 
+func (ctx *parserCtx) instructionNewValueString() {
+	ctx.res = append(ctx.res, 0, actionValue, valueString)
+}
+
 // represends:
 //
 // {a: "a", b: "b", ...}

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -42,13 +42,13 @@ const (
 // ^- Kind
 //
 // writes:
-// 0 [actionNewOperator] [kind]
+// 0 [actionNewOperator] [kind] [f (has no arguments (t = has arguments))]
 //
 // additional append:
 // [name...]
 func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
 	res := len(ctx.res)
-	ctx.res = append(ctx.res, 0, actionOperator, kind)
+	ctx.res = append(ctx.res, 0, actionOperator, kind, 'f')
 	return res
 }
 

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -118,6 +118,18 @@ func (ctx *parserCtx) instructionNewValueObject() {
 	ctx.res = append(ctx.res, 0, actionValue, valueObject)
 }
 
+func (ctx *parserCtx) instructionNewValueBoolean(val bool) {
+	if val {
+		ctx.res = append(ctx.res, 0, actionValue, valueBoolean, '1')
+	} else {
+		ctx.res = append(ctx.res, 0, actionValue, valueBoolean, '0')
+	}
+}
+
+func (ctx *parserCtx) instructionNewValueNull() {
+	ctx.res = append(ctx.res, 0, actionValue, valueNull)
+}
+
 // represends:
 //
 // {a: "a", b: "b", ...}

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -113,15 +113,15 @@ func (ctx *parserCtx) instructionNewField() {
 // }
 //
 // writes:
-// 0 [actionSpread] [t/f (t = inline fragment, f = pointer to fragment)]
+// 0 [actionSpread] [t/f (t = inline fragment, f = pointer to fragment)] [directives count in uint8]
 //
 // additional required append:
 // [Typename or Fragment Name]
 func (ctx *parserCtx) instructionNewFragmentSpread(isInline bool) {
 	if isInline {
-		ctx.res = append(ctx.res, 0, actionSpread, 't')
+		ctx.res = append(ctx.res, 0, actionSpread, 't', 0)
 	} else {
-		ctx.res = append(ctx.res, 0, actionSpread, 'f')
+		ctx.res = append(ctx.res, 0, actionSpread, 'f', 0)
 	}
 }
 

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -142,6 +142,10 @@ func (ctx *parserCtx) instructionNewValueVariable() {
 	ctx.res = append(ctx.res, 0, actionValue, valueVariable)
 }
 
+func (ctx *parserCtx) instructionNewValueInt() {
+	ctx.res = append(ctx.res, 0, actionValue, valueInt)
+}
+
 // represends:
 //
 // {a: "a", b: "b", ...}

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -3,11 +3,27 @@ package graphql
 type action = byte
 
 const (
-	actionEnd      action = 'e'
-	actionOperator action = 'o'
-	actionField    action = 'f'
-	actionSpread   action = 's'
-	actionFragment action = 'F'
+	actionEnd              action = 'e'
+	actionOperator         action = 'o'
+	actionField            action = 'f'
+	actionSpread           action = 's'
+	actionFragment         action = 'F'
+	actionValue            action = 'v'
+	actionObjectValueField action = 'u'
+)
+
+type valueKind = byte
+
+const (
+	valueVariable valueKind = 'v'
+	valueInt      valueKind = 'i'
+	valueFloat    valueKind = 'f'
+	valueString   valueKind = 's'
+	valueBoolean  valueKind = 'b'
+	valueNull     valueKind = 'n'
+	valueEnum     valueKind = 'e'
+	valueList     valueKind = 'l'
+	valueObject   valueKind = 'o'
 )
 
 type operatorKind = byte
@@ -86,6 +102,37 @@ func (ctx *parserCtx) instructionNewFragmentSpread(isInline bool) {
 	} else {
 		ctx.res = append(ctx.res, 0, actionSpread, 'f')
 	}
+}
+
+// represends:
+//
+// {a: "a", b: "b", ...}
+// ^- This represends the start of a set
+// AND
+// (a: "a", b: "b", ...)
+// ^- This represends the start of a set
+//
+// writes:
+// 0 [actionValue] [valueObject]
+func (ctx *parserCtx) instructionNewValueObject() {
+	ctx.res = append(ctx.res, 0, actionValue, valueObject)
+}
+
+// represends:
+//
+// {a: "a", b: "b", ...}
+//          ^- This represends a field inside a set
+// AND
+// (a: "a", b: "b", ...)
+//          ^- This represends a field inside a set
+//
+// writes:
+// 0 [actionObjectValueField]
+//
+// additional required append:
+// [fieldname]
+func (ctx *parserCtx) instructionStartNewValueObjectField() {
+	ctx.res = append(ctx.res, 0, actionObjectValueField)
 }
 
 // represends:

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -118,6 +118,10 @@ func (ctx *parserCtx) instructionNewValueObject() {
 	ctx.res = append(ctx.res, 0, actionValue, valueObject)
 }
 
+func (ctx *parserCtx) instructionNewValueList() {
+	ctx.res = append(ctx.res, 0, actionValue, valueList)
+}
+
 func (ctx *parserCtx) instructionNewValueBoolean(val bool) {
 	if val {
 		ctx.res = append(ctx.res, 0, actionValue, valueBoolean, '1')

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -3,16 +3,17 @@ package graphql
 type action = byte
 
 const (
-	actionEndClosure action = iota + 1
-	actionNewOperator
+	actionEnd      action = 'e'
+	actionOperator action = 'o'
+	actionField    action = 'f'
 )
 
 type operatorKind = byte
 
 const (
-	operatorQuery operatorKind = iota + 1
-	operatorMutation
-	operatorSubscription
+	operatorQuery        operatorKind = 'q'
+	operatorMutation     operatorKind = 'm'
+	operatorSubscription operatorKind = 's'
 )
 
 // represends:
@@ -21,24 +22,40 @@ const (
 // ^- Kind
 //
 // writes:
-// 0 [actionNewOperator] [kind]
+// i [actionNewOperator] [kind]
 //
 // additional append:
 // [name...]
 func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
 	res := len(ctx.res)
-	ctx.res = append(ctx.res, 0, actionNewOperator, kind)
+	ctx.res = append(ctx.res, 0, actionOperator, kind)
 	return res
 }
 
 // represends:
 //
+// query { a }
+//         ^
+//
+// writes:
+// i [actionField]
+func (ctx *parserCtx) instructionNewField() {
+	ctx.res = append(ctx.res, 0, actionField)
+}
+
+// represends:
+//
 // query { }
-//         ^- Closure
+//         ^- End
 //
 // query { a { } }
-//             ^- Closure
+//             ^- End
 //
-func (ctx *parserCtx) instructionEndClosure() {
-	ctx.res = append(ctx.res, 0, actionEndClosure)
+// query { a  }
+//          ^- End
+//
+// writes:
+// i [actionEndClosure]
+func (ctx *parserCtx) instructionEnd() {
+	ctx.res = append(ctx.res, 0, actionEnd)
 }

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -57,6 +57,11 @@ func (ctx *parserCtx) instructionNewFragment() int {
 //
 // writes:
 // 0 [actionField]
+//
+// additional required append:
+// [Fieldname] 0
+// OR
+// [Alias] 0 [Fieldname]
 func (ctx *parserCtx) instructionNewField() {
 	ctx.res = append(ctx.res, 0, actionField)
 }

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -12,6 +12,7 @@ const (
 	actionFragment         action = 'F'
 	actionValue            action = 'v'
 	actionObjectValueField action = 'u'
+	actionDirective        action = 'd'
 )
 
 type valueKind = byte
@@ -42,13 +43,13 @@ const (
 // ^- Kind
 //
 // writes:
-// 0 [actionNewOperator] [kind] [f (has no arguments (t = has arguments))]
+// 0 [actionNewOperator] [kind] [f (has no arguments (t = has arguments))] [nr of directives in uint8]
 //
 // additional append:
 // [name...]
 func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
 	res := len(ctx.res)
-	ctx.res = append(ctx.res, 0, actionOperator, kind, 'f')
+	ctx.res = append(ctx.res, 0, actionOperator, kind, 'f', 0)
 	return res
 }
 
@@ -122,6 +123,19 @@ func (ctx *parserCtx) instructionNewFragmentSpread(isInline bool) {
 	} else {
 		ctx.res = append(ctx.res, 0, actionSpread, 'f')
 	}
+}
+
+// represends:
+//
+// @banana(arg: 2)
+//
+// writes:
+// 0 [actionDirective] [t/f (t = has arguments, f = no arguments)]
+//
+// additional required append:
+// [Directive name]
+func (ctx *parserCtx) instructionNewDirective() {
+	ctx.res = append(ctx.res, 0, actionDirective, 'f')
 }
 
 // represends:

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -5,6 +5,8 @@ type action = byte
 const (
 	actionEnd              action = 'e'
 	actionOperator         action = 'o'
+	actionOperatorArgs     action = 'A'
+	actionOperatorArg      action = 'a'
 	actionField            action = 'f'
 	actionSpread           action = 's'
 	actionFragment         action = 'F'
@@ -48,6 +50,24 @@ func (ctx *parserCtx) instructionNewOperation(kind operatorKind) int {
 	res := len(ctx.res)
 	ctx.res = append(ctx.res, 0, actionOperator, kind)
 	return res
+}
+
+func (ctx *parserCtx) instructionNewOperationArgs() {
+	ctx.res = append(ctx.res, 0, actionOperatorArgs)
+}
+
+// represends:
+//
+// query foo(banana: String) {
+//             ^- actionOperatorArg
+//
+// writes:
+// 0 [actionOperatorArg]
+//
+// additional required append:
+// [Name] 0 [Graphql Type] 0 ['t'/'f' (t = has default value (next instruction will value), f = no default value)]
+func (ctx *parserCtx) instructionNewOperationArg() {
+	ctx.res = append(ctx.res, 0, actionOperatorArg)
 }
 
 // represends:

--- a/bytecode/bytecode_instructions.go
+++ b/bytecode/bytecode_instructions.go
@@ -93,14 +93,14 @@ func (ctx *parserCtx) instructionNewFragment() int {
 //         ^
 //
 // writes:
-// 0 [actionField]
+// 0 [actionField] [directives count as uint8]
 //
 // additional required append:
 // [Fieldname] 0
 // OR
 // [Alias] 0 [Fieldname]
 func (ctx *parserCtx) instructionNewField() {
-	ctx.res = append(ctx.res, 0, actionField)
+	ctx.res = append(ctx.res, 0, actionField, 0)
 }
 
 // represends:

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -227,7 +227,8 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 		foo
 		// no field alias
 		e
-		sfbaz // fragment spread pointing to fragment with name baz
+		sf  // fragment spread pointing
+		baz // fragment name
 		f
 		bar
 		// no field alias
@@ -253,7 +254,8 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 		foo
 		// no field alias
 		e
-		sfonline // fragment spread pointing to fragment with name online
+		sf     // fragment spread pointing
+		online // fragment name
 		f
 		bar
 		// no field alias
@@ -274,7 +276,8 @@ func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 		foo
 		// no field alias
 		e
-		stbaz     // fragment spread with typename baz
+		st       // inline fragment spread
+		baz      // fragment name
 		f
 		bazField // fragment field
 		// no field alias

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -417,7 +417,8 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		injectCodeSurviveTest(query, [][]byte{{'+'}, {'.'}, {'e'}, {'"'}, {0}, {'\n'}, {'\r'}})
 	}
 
-	injectCodeSurviveTest(`query {baz(foo: "\a\b\c")}`, [][]byte{{'b'}, {'f'}, {'n'}, {'r'}, {'t'}, {'u'}})
+	// To improve code cov
+	injectCodeSurviveTest(`query {baz(foo: "\a\b\c")}`, [][]byte{{'b'}, {'f'}, {'n'}, {'r'}, {'t'}, {'u'}, {'\b'}, {'\f'}, {'\n'}, {'\r'}, {'\t'}})
 }
 
 func TestParseMultipleArguments(t *testing.T) {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -88,3 +88,35 @@ func TestParseQueryWithField(t *testing.T) {
 		e           // end operator
 	`)
 }
+
+func TestParseQueryWithMultipleFields(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field
+		other
+	}`, `
+		oq          // query operator
+		fsome_field // field with name some_field
+		e           // end field with name some_field
+		fother      // field with name other
+		e           // end field with name other
+		e           // end operator
+	`)
+}
+
+func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo
+			bar
+		}
+	}`, `
+		oq          // query operator
+		fsome_field // field with name some_field
+		ffoo        // field with name foo
+		e           // end of foo
+		fbar        // field with name bar
+		e           // end of bar
+		e           // end of some_field
+		e           // end operator
+	`)
+}

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -45,7 +45,7 @@ func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
 	for _, err := range errs {
 		panic(err.Error())
 	}
-	Equal(t, formatHumanReadableQuery(expectedResult), formatResToHumandReadable(res))
+	Equal(t, formatHumanReadableQuery(expectedResult), formatResToHumandReadable(res), query)
 }
 
 func TestParseSimpleQuery(t *testing.T) {
@@ -258,9 +258,11 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		input  string
 		output string
 	}{
-		{`true`, `vb1`},
-		{`false`, `vb0`},
-		{`null`, `vn`},
+		{`true`, `vb1`},         // boolean
+		{`false`, `vb0`},        // boolean
+		{`null`, `vn`},          // null
+		{`$banana`, `v$banana`}, // variable reference
+		{`BANANA`, `veBANANA`},  // Enum
 	}
 
 	for _, option := range options {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -253,6 +253,33 @@ func TestParseArgumentsWithoutInput(t *testing.T) {
 	`)
 }
 
+func TestParseArgumentValueTypes(t *testing.T) {
+	options := []struct {
+		input  string
+		output string
+	}{
+		{`true`, `vb1`},
+		{`false`, `vb0`},
+		{`null`, `vn`},
+	}
+
+	for _, option := range options {
+		parseQueryAndExpectResult(t, `query {baz(foo: `+option.input+`)}`, `
+			oq
+			fbaz // field with alias foo
+			// no alias
+			vo   // value of kind object (these are the arguments)
+			ufoo // key foo
+			`+option.output+`
+			e    // end of value object / arguments
+			e    // end of field
+			e
+		`)
+
+	}
+
+}
+
 func TestParseFragment(t *testing.T) {
 	parseQueryAndExpectResult(t, `fragment Foo on Bar {}`, `
 		FFoo // fragment with name Foo

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -467,3 +467,24 @@ func TestParseQueryWithFieldDirective(t *testing.T) {
 		e
 	`)
 }
+
+func TestParseQueryWithFragmentDirective(t *testing.T) {
+	// Inline fragment
+	parseQueryAndExpectResult(t, `{... on baz @foo {}}`, `
+		oqf
+
+		st`+"\x01"+`baz // fragment with 1 directive
+		dffoo           // directive with name foo and no arguments
+		e
+		e
+	`)
+
+	// Pointer to fragment
+	parseQueryAndExpectResult(t, `{...baz@foo}`, `
+		oqf
+
+		sf`+"\x01"+`baz // fragment with 1 directive
+		dffoo           // directive with name foo and no arguments
+		e
+	`)
+}

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -121,6 +121,51 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 	`)
 }
 
+func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo
+			... baz
+			bar
+		}
+	}`, `
+		oq
+		fsome_field
+		ffoo
+		e
+		sfbaz // fragment spread pointing to fragment with name baz
+		fbar
+		e
+		e
+		e
+	`)
+}
+
+func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo
+			... on baz {
+				bazField
+			}
+			bar
+		}
+	}`, `
+		oq
+		fsome_field
+		ffoo
+		e
+		stbaz     // fragment spread with typename baz
+		fbazField // fragment field
+		e         // end of fragment field
+		e         // end of inline fragment
+		fbar
+		e
+		e
+		e
+	`)
+}
+
 func TestParseFragment(t *testing.T) {
 	parseQueryAndExpectResult(t, `fragment Foo on Bar {}`, `
 		FFoo // fragment with name Foo

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -50,42 +50,42 @@ func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
 
 func TestParseSimpleQuery(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}`, `
-		oq // [operator] [query]
+		oqf // [operator] [query]
 		e  // [end of operator]
 	`)
 }
 
 func TestParseSimpleQueryWrittenOut(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {}`, `
-		oq // operator of type query
+		oqf // operator of type query
 		e  // end of operator
 	`)
 }
 
 func TestParseSimpleMutation(t *testing.T) {
 	parseQueryAndExpectResult(t, `mutation {}`, `
-		om // operator of type mutation
+		omf // operator of type mutation
 		e  // end of operator
 	`)
 }
 
 func TestParseSimpleSubscription(t *testing.T) {
 	parseQueryAndExpectResult(t, `subscription {}`, `
-		os // operator of type subscription
+		osf // operator of type subscription
 		e  // end of operator
 	`)
 }
 
 func TestParseQueryWithName(t *testing.T) {
 	parseQueryAndExpectResult(t, `query banana {}`, `
-		oqbanana // operator of type query with name banana
+		oqfbanana // operator of type query with name banana
 		e        // end of operator
 	`)
 }
 
 func TestParseQuerywithArgs(t *testing.T) {
 	parseQueryAndExpectResult(t, `query banana(quality: [Int]) {}`, `
-		oqbanana // operator of type query with name banana
+		oqtbanana // operator of type query with name banana
 		A        // operator args
         aquality // argument with name banana
         lnInt    // argument of type list with an inner type Int
@@ -95,7 +95,7 @@ func TestParseQuerywithArgs(t *testing.T) {
 	`)
 
 	parseQueryAndExpectResult(t, `query banana(quality: [Int!]! = [10]) {}`, `
-		oqbanana // operator of type query with name banana
+		oqtbanana // operator of type query with name banana
 		A        // operator args
         aquality // argument with name banana
         LNInt    // argument of type required list with an inner type Int also required
@@ -110,9 +110,9 @@ func TestParseQuerywithArgs(t *testing.T) {
 
 func TestParseMultipleSimpleQueries(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}{}`, `
-		oq // operator 1
+		oqf // operator 1
 		e  // end of operator 1
-		oq // operator 2
+		oqf // operator 2
 		e  // end of operator 2
 	`)
 }
@@ -122,9 +122,9 @@ func TestParseMultipleQueries(t *testing.T) {
 		query a {}
 		mutation b {}
 	`, `
-		oqa // query operator 1
+		oqfa // query operator 1
 		e   // end of operator 1
-		omb // mutation operator 2
+		omfb // mutation operator 2
 		e   // end of operator 2
 	`)
 }
@@ -133,7 +133,7 @@ func TestParseQueryWithField(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {
 		some_field
 	}`, `
-		oq          // query operator
+		oqf          // query operator
 		fsome_field // field with name some_field
 		// no field alias
 		e           // end field
@@ -143,7 +143,7 @@ func TestParseQueryWithField(t *testing.T) {
 
 func TestParseQueryWithMultipleFields(t *testing.T) {
 	expectedOutput := `
-		oq          // query operator
+		oqf          // query operator
 		fsome_field // field with name some_field
 		// no field alias
 		e           // end field with name some_field
@@ -176,7 +176,7 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 			bar
 		}
 	}`, `
-		oq          // query operator
+		oqf          // query operator
 		fsome_field // field with name some_field
 		// no field alias
 		ffoo        // field with name foo
@@ -198,7 +198,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 			bar
 		}
 	}`, `
-		oq
+		oqf
 		fsome_field
 		// no field alias
 		ffoo
@@ -220,7 +220,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 			bar
 		}
 	}`, `
-		oq
+		oqf
 		fsome_field
 		// no field alias
 		ffoo
@@ -237,7 +237,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 
 func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 	expectedOutput := `
-		oq
+		oqf
 		fsome_field
 		// no field alias
 		ffoo
@@ -280,7 +280,7 @@ func TestParseAlias(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {
 		foo: baz
 	}`, `
-		oq
+		oqf
 		ffoo // field with alias foo
 		baz  // field name
 		e    // end of field
@@ -292,7 +292,7 @@ func TestParseArgumentsWithoutInput(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {
 		baz()
 	}`, `
-		oq
+		oqf
 		fbaz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)
@@ -327,7 +327,7 @@ func TestParseArgumentValueTypes(t *testing.T) {
 
 	for _, option := range options {
 		parseQueryAndExpectResult(t, `query {baz(foo: `+option.input+`)}`, `
-			oq
+			oqf
 			fbaz // field with alias foo
 			// no alias
 			vo   // value of kind object (these are the arguments)
@@ -342,7 +342,7 @@ func TestParseArgumentValueTypes(t *testing.T) {
 
 func TestParseMultipleArguments(t *testing.T) {
 	expect := `
-		oq
+		oqf
 		fbaz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -78,6 +78,15 @@ func TestParseQueryWithName(t *testing.T) {
 	`)
 }
 
+func TestParseMultipleSimpleQueries(t *testing.T) {
+	parseQueryAndExpectResult(t, `{}{}`, `
+		oq // operator 1
+		e  // end of operator 1
+		oq // operator 2
+		e  // end of operator 2
+	`)
+}
+
 func TestParseQueryWithField(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {
 		some_field

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -120,3 +120,26 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 		e           // end operator
 	`)
 }
+
+func TestParseFragment(t *testing.T) {
+	parseQueryAndExpectResult(t, `fragment Foo on Bar {}`, `
+		FFoo // fragment with name Foo
+		Bar  // fragment type name
+		e    // end of fragment
+	`)
+}
+
+func TestParseFragmentWithFields(t *testing.T) {
+	parseQueryAndExpectResult(t, `fragment Foo on Bar {
+		fieldA
+		bField
+	}`, `
+		FFoo    // fragment with name Foo
+		Bar     // fragment type name
+		ffieldA
+		e
+		fbField
+		e
+		e       // end of fragment
+	`)
+}

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -1,0 +1,43 @@
+package graphql
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+func parseQuery(query string) ([]byte, []error) {
+	i := parserCtx{
+		res:    []byte{},
+		query:  []byte(query),
+		errors: []error{},
+	}
+	i.parseQueryToBytecode()
+	return i.res, i.errors
+}
+
+func formatHumanReadableQuery(result string) string {
+	result = strings.TrimSpace(result)
+	result = strings.ReplaceAll(result, " ", "")
+	result = strings.ReplaceAll(result, "\t", "")
+	result = strings.ReplaceAll(result, "\r", "")
+	lines := strings.Split(result, "\n")
+	for i, line := range lines {
+		lines[i] = string(0) + strings.Split(line, "//")[0]
+	}
+	return result
+}
+
+func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
+	res, errs := parseQuery(query)
+	Equal(t, 0, len(errs))
+	Equal(t, formatHumanReadableQuery(expectedResult), string(res))
+}
+
+func TestParseSimpleQuery(t *testing.T) {
+	parseQueryAndExpectResult(t, `{}`, `
+		oq // [operator] [query]
+		e  // [end of operator]
+	`)
+}

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -35,6 +35,11 @@ func formatResToHumandReadable(result []byte) string {
 	return strings.TrimSpace(string(result))
 }
 
+// parseQueryAndExpectResult is a readable tester for the bytecode
+// The `expectedResult` is formatted like so:
+// - Enter == null byte
+// - Spaces characters are removed ('\r','\t',' ')
+// - Comments can be made using // and will be trimmed away in the output
 func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
 	res, errs := parseQuery(query)
 	for _, err := range errs {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -282,11 +282,16 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		input  string
 		output string
 	}{
-		{`true`, `vb1`},         // boolean
-		{`false`, `vb0`},        // boolean
-		{`null`, `vn`},          // null
-		{`$banana`, `v$banana`}, // variable reference
-		{`BANANA`, `veBANANA`},  // Enum
+		{`true`, `vb1`},                      // boolean
+		{`false`, `vb0`},                     // boolean
+		{`null`, `vn`},                       // null
+		{`$banana`, `v$banana`},              // variable reference
+		{`BANANA`, `veBANANA`},               // Enum
+		{`{}`, "vo\ne"},                      // Object
+		{`[]`, "vl\ne"},                      // List
+		{`{a: true}`, "vo\nua\nvb1\ne"},      // Object
+		{`[true, false]`, "vl\nvb1\nvb0\ne"}, // List
+		{`[true false]`, "vl\nvb1\nvb0\ne"},  // List
 	}
 
 	for _, option := range options {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -287,6 +287,12 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		{`null`, `vn`},                       // null
 		{`$banana`, `v$banana`},              // variable reference
 		{`BANANA`, `veBANANA`},               // Enum
+		{`10`, `vi10`},                       // Int
+		{`-20`, `vi-20`},                     // Int
+		{`10.1`, `vf10.1`},                   // Float
+		{`-20.1`, `vf-20.1`},                 // Float
+		{`10.1E3`, `vf10.1E3`},               // Float
+		{`-20.1e-3`, `vf-20.1E-3`},           // Float
 		{`{}`, "vo\ne"},                      // Object
 		{`[]`, "vl\ne"},                      // List
 		{`{a: true}`, "vo\nua\nvb1\ne"},      // Object

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -160,6 +160,25 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 		e
 		e
 	`)
+
+	// A query that starts with "on" should parse as a fragment pointer
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo
+			... online
+			bar
+		}
+	}`, `
+		oq
+		fsome_field
+		ffoo
+		e
+		sfonline // fragment spread pointing to fragment with name online
+		fbar
+		e
+		e
+		e
+	`)
 }
 
 func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -239,6 +239,20 @@ func TestParseAlias(t *testing.T) {
 	`)
 }
 
+func TestParseArgumentsWithoutInput(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		baz()
+	}`, `
+		oq
+		fbaz // field with alias foo
+		// no alias
+		vo   // value of kind object (these are the arguments)
+		e    // end of value object / arguments
+		e    // end of field
+		e
+	`)
+}
+
 func TestParseFragment(t *testing.T) {
 	parseQueryAndExpectResult(t, `fragment Foo on Bar {}`, `
 		FFoo // fragment with name Foo

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -384,6 +384,11 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		{`-20.1`, `vf-20.1`},                 // Float
 		{`10.1E3`, `vf10.1E3`},               // Float
 		{`-20.1e-3`, `vf-20.1E-3`},           // Float
+		{`"abc"`, `vsabc`},                   // String
+		{`""`, `vs`},                         // String
+		{`"\b"`, "vs\b"},                     // String
+		{`"a\u0021b"`, "vsa!b"},              // String
+		{`"a\u03A3b"`, "vsaΣb"},              // String
 		{`{}`, "vo\ne"},                      // Object
 		{`[]`, "vl\ne"},                      // List
 		{`{a: true}`, "vo\nua\nvb1\ne"},      // Object

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -83,6 +83,31 @@ func TestParseQueryWithName(t *testing.T) {
 	`)
 }
 
+func TestParseQuerywithArgs(t *testing.T) {
+	parseQueryAndExpectResult(t, `query banana(quality: [Int]) {}`, `
+		oqbanana // operator of type query with name banana
+		A        // operator args
+        aquality // argument with name banana
+        lnInt    // argument of type list with an inner type Int
+		f        // this argument has default values
+		e        // end of operator arguments
+		e        // end of operator
+	`)
+
+	parseQueryAndExpectResult(t, `query banana(quality: [Int!]! = [10]) {}`, `
+		oqbanana // operator of type query with name banana
+		A        // operator args
+        aquality // argument with name banana
+        LNInt    // argument of type required list with an inner type Int also required
+		t        // this argument has default values
+		vl       // list value
+		vi10     // value of type int with value 10
+		e        // end of list value
+		e        // end of operator arguments
+		e        // end of operator
+	`)
+}
+
 func TestParseMultipleSimpleQueries(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}{}`, `
 		oq // operator 1

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -105,6 +105,7 @@ func TestParseQueryWithField(t *testing.T) {
 	}`, `
 		oq          // query operator
 		fsome_field // field with name some_field
+		// no field alias
 		e           // end field
 		e           // end operator
 	`)
@@ -117,8 +118,10 @@ func TestParseQueryWithMultipleFields(t *testing.T) {
 	}`, `
 		oq          // query operator
 		fsome_field // field with name some_field
+    	// no field alias
 		e           // end field with name some_field
 		fother      // field with name other
+		// no field alias
 		e           // end field with name other
 		e           // end operator
 	`)
@@ -133,9 +136,12 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 	}`, `
 		oq          // query operator
 		fsome_field // field with name some_field
+		// no field alias
 		ffoo        // field with name foo
+		// no field alias
 		e           // end of foo
 		fbar        // field with name bar
+		// no field alias
 		e           // end of bar
 		e           // end of some_field
 		e           // end operator
@@ -152,10 +158,13 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 	}`, `
 		oq
 		fsome_field
+		// no field alias
 		ffoo
+		// no field alias
 		e
 		sfbaz // fragment spread pointing to fragment with name baz
 		fbar
+		// no field alias
 		e
 		e
 		e
@@ -171,10 +180,13 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 	}`, `
 		oq
 		fsome_field
+		// no field alias
 		ffoo
+		// no field alias
 		e
 		sfonline // fragment spread pointing to fragment with name online
 		fbar
+		// no field alias
 		e
 		e
 		e
@@ -193,15 +205,31 @@ func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 	}`, `
 		oq
 		fsome_field
+		// no field alias
 		ffoo
+		// no field alias
 		e
 		stbaz     // fragment spread with typename baz
 		fbazField // fragment field
+		// no field alias
 		e         // end of fragment field
 		e         // end of inline fragment
 		fbar
+		// no field alias
 		e
 		e
+		e
+	`)
+}
+
+func TestParseAlias(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		foo: baz
+	}`, `
+		oq
+		ffoo // field with alias foo
+		baz  // field name
+		e    // end of field
 		e
 	`)
 }
@@ -222,8 +250,10 @@ func TestParseFragmentWithFields(t *testing.T) {
 		FFoo    // fragment with name Foo
 		Bar     // fragment type name
 		ffieldA
+		// no field alias
 		e
 		fbField
+		// no field alias
 		e
 		e       // end of fragment
 	`)

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -430,3 +430,40 @@ func TestParseFragmentWithFields(t *testing.T) {
 		e       // end of fragment
 	`)
 }
+
+func TestParseOperatonDirective(t *testing.T) {
+	parseQueryAndExpectResult(t, `query a @banana @peer {}`, `
+		oqf`+"\x02"+`a // new operator with name a and 2 directives
+		dfbanana       // directive with no arguments and name banana
+		dfpeer         // directive with no arguments and name peer
+		e              // end of operator
+	`)
+}
+
+func TestParseOperatonDirectiveWithArgs(t *testing.T) {
+	parseQueryAndExpectResult(t, `query a @banana(a: 1, b: 2) {}`, `
+		oqf`+"\x01"+`a // new operator with name a and 2 directives
+		dtbanana       // directive with arguments and name banana
+		vo             // value with type object (start directive arguments values)
+        ua             // object field a
+        vi1            // value type int with value 1
+        ub             // object field b
+        vi2            // value type int with value 2
+		e              // end object (end directive arguments)
+		e              // end of operator
+	`)
+}
+
+func TestParseQueryWithFieldDirective(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field @banana
+	}`, `
+		oqf
+		// No directives
+		f`+"\x01"+`some_field // field with 1 arguments
+		// no field alias
+		dfbanana              // directive banana with no arguments
+		e
+		e
+	`)
+}

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -87,6 +87,18 @@ func TestParseMultipleSimpleQueries(t *testing.T) {
 	`)
 }
 
+func TestParseMultipleQueries(t *testing.T) {
+	parseQueryAndExpectResult(t, `
+		query a {}
+		mutation b {}
+	`, `
+		oqa // query operator 1
+		e   // end of operator 1
+		omb // mutation operator 2
+		e   // end of operator 2
+	`)
+}
+
 func TestParseQueryWithField(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {
 		some_field

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -51,6 +51,7 @@ func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
 func TestParseSimpleQuery(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}`, `
 		oqf // [operator] [query]
+		// No directives
 		e  // [end of operator]
 	`)
 }
@@ -58,6 +59,7 @@ func TestParseSimpleQuery(t *testing.T) {
 func TestParseSimpleQueryWrittenOut(t *testing.T) {
 	parseQueryAndExpectResult(t, `query {}`, `
 		oqf // operator of type query
+		// No directives
 		e  // end of operator
 	`)
 }
@@ -65,6 +67,7 @@ func TestParseSimpleQueryWrittenOut(t *testing.T) {
 func TestParseSimpleMutation(t *testing.T) {
 	parseQueryAndExpectResult(t, `mutation {}`, `
 		omf // operator of type mutation
+		// No directives
 		e  // end of operator
 	`)
 }
@@ -72,20 +75,23 @@ func TestParseSimpleMutation(t *testing.T) {
 func TestParseSimpleSubscription(t *testing.T) {
 	parseQueryAndExpectResult(t, `subscription {}`, `
 		osf // operator of type subscription
+		// No directives
 		e  // end of operator
 	`)
 }
 
 func TestParseQueryWithName(t *testing.T) {
 	parseQueryAndExpectResult(t, `query banana {}`, `
-		oqfbanana // operator of type query with name banana
+		oqf      // operator of type query
+		banana   // operator name
 		e        // end of operator
 	`)
 }
 
 func TestParseQuerywithArgs(t *testing.T) {
 	parseQueryAndExpectResult(t, `query banana(quality: [Int]) {}`, `
-		oqtbanana // operator of type query with name banana
+		oqt      // operator of type query
+		banana   // operator name
 		A        // operator args
         aquality // argument with name banana
         lnInt    // argument of type list with an inner type Int
@@ -95,7 +101,8 @@ func TestParseQuerywithArgs(t *testing.T) {
 	`)
 
 	parseQueryAndExpectResult(t, `query banana(quality: [Int!]! = [10]) {}`, `
-		oqtbanana // operator of type query with name banana
+		oqt      // operator of type query
+		banana   // operator name
 		A        // operator args
         aquality // argument with name banana
         LNInt    // argument of type required list with an inner type Int also required
@@ -111,8 +118,10 @@ func TestParseQuerywithArgs(t *testing.T) {
 func TestParseMultipleSimpleQueries(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}{}`, `
 		oqf // operator 1
+		// No directives
 		e  // end of operator 1
 		oqf // operator 2
+		// No directives
 		e  // end of operator 2
 	`)
 }
@@ -122,9 +131,11 @@ func TestParseMultipleQueries(t *testing.T) {
 		query a {}
 		mutation b {}
 	`, `
-		oqfa // query operator 1
+		oqf // query operator 1
+		a   // operator 1 name
 		e   // end of operator 1
-		omfb // mutation operator 2
+		omf // mutation operator 2
+		b   // operator 2 name
 		e   // end of operator 2
 	`)
 }
@@ -134,6 +145,7 @@ func TestParseQueryWithField(t *testing.T) {
 		some_field
 	}`, `
 		oqf          // query operator
+		// No directives
 		fsome_field // field with name some_field
 		// no field alias
 		e           // end field
@@ -144,6 +156,7 @@ func TestParseQueryWithField(t *testing.T) {
 func TestParseQueryWithMultipleFields(t *testing.T) {
 	expectedOutput := `
 		oqf          // query operator
+		// No directives
 		fsome_field // field with name some_field
 		// no field alias
 		e           // end field with name some_field
@@ -177,6 +190,7 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 		}
 	}`, `
 		oqf          // query operator
+		// No directives
 		fsome_field // field with name some_field
 		// no field alias
 		ffoo        // field with name foo
@@ -199,6 +213,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 		}
 	}`, `
 		oqf
+		// No directives
 		fsome_field
 		// no field alias
 		ffoo
@@ -221,6 +236,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 		}
 	}`, `
 		oqf
+		// No directives
 		fsome_field
 		// no field alias
 		ffoo
@@ -238,6 +254,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 	expectedOutput := `
 		oqf
+		// No directives
 		fsome_field
 		// no field alias
 		ffoo
@@ -281,6 +298,7 @@ func TestParseAlias(t *testing.T) {
 		foo: baz
 	}`, `
 		oqf
+		// No directives
 		ffoo // field with alias foo
 		baz  // field name
 		e    // end of field
@@ -293,6 +311,7 @@ func TestParseArgumentsWithoutInput(t *testing.T) {
 		baz()
 	}`, `
 		oqf
+		// No directives
 		fbaz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)
@@ -328,6 +347,7 @@ func TestParseArgumentValueTypes(t *testing.T) {
 	for _, option := range options {
 		parseQueryAndExpectResult(t, `query {baz(foo: `+option.input+`)}`, `
 			oqf
+			// No directives
 			fbaz // field with alias foo
 			// no alias
 			vo   // value of kind object (these are the arguments)
@@ -343,6 +363,7 @@ func TestParseArgumentValueTypes(t *testing.T) {
 func TestParseMultipleArguments(t *testing.T) {
 	expect := `
 		oqf
+		// No directives
 		fbaz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -117,19 +117,31 @@ func TestParseQueryWithField(t *testing.T) {
 }
 
 func TestParseQueryWithMultipleFields(t *testing.T) {
-	parseQueryAndExpectResult(t, `query {
-		some_field
-		other
-	}`, `
+	expectedOutput := `
 		oq          // query operator
 		fsome_field // field with name some_field
-    	// no field alias
+		// no field alias
 		e           // end field with name some_field
 		fother      // field with name other
 		// no field alias
 		e           // end field with name other
 		e           // end operator
-	`)
+	`
+
+	parseQueryAndExpectResult(t, `query {
+		some_field
+		other
+	}`, expectedOutput)
+
+	parseQueryAndExpectResult(t, `query {
+		some_field,
+		other
+	}`, expectedOutput)
+
+	parseQueryAndExpectResult(t, `query {
+		some_field ,
+		other      ,
+	}`, expectedOutput)
 }
 
 func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
@@ -199,15 +211,7 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 }
 
 func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
-	parseQueryAndExpectResult(t, `query {
-		some_field {
-			foo
-			... on baz {
-				bazField
-			}
-			bar
-		}
-	}`, `
+	expectedOutput := `
 		oq
 		fsome_field
 		// no field alias
@@ -224,7 +228,27 @@ func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 		e
 		e
 		e
-	`)
+	`
+
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo
+			... on baz {
+				bazField
+			}
+			bar
+		}
+	}`, expectedOutput)
+
+	parseQueryAndExpectResult(t, `query {
+		some_field {
+			foo,
+			... on baz {
+				bazField
+			},
+			bar,
+		}
+	}`, expectedOutput)
 }
 
 func TestParseAlias(t *testing.T) {
@@ -277,9 +301,27 @@ func TestParseArgumentValueTypes(t *testing.T) {
 			e    // end of field
 			e
 		`)
-
 	}
+}
 
+func TestParseMultipleArguments(t *testing.T) {
+	expect := `
+		oq
+		fbaz // field with alias foo
+		// no alias
+		vo   // value of kind object (these are the arguments)
+		ufoo // key foo
+		vb1  // boolean value with data true
+		ubar // key bar
+		vb0  // boolean value with data false
+		e    // end of value object / arguments
+		e    // end of field
+		e
+	`
+
+	parseQueryAndExpectResult(t, `query {baz(foo: true, bar: false)}`, expect)
+	parseQueryAndExpectResult(t, `query {baz(foo: true bar: false)}`, expect)
+	parseQueryAndExpectResult(t, `query {baz(foo: true, bar: false,)}`, expect)
 }
 
 func TestParseFragment(t *testing.T) {

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -24,20 +25,66 @@ func formatHumanReadableQuery(result string) string {
 	result = strings.ReplaceAll(result, "\r", "")
 	lines := strings.Split(result, "\n")
 	for i, line := range lines {
-		lines[i] = string(0) + strings.Split(line, "//")[0]
+		lines[i] = strings.Split(line, "//")[0]
 	}
-	return result
+	return strings.Join(lines, "\n")
+}
+
+func formatResToHumandReadable(result []byte) string {
+	result = bytes.Join(bytes.Split(result, []byte{0}), []byte{'\n'})
+	return strings.TrimSpace(string(result))
 }
 
 func parseQueryAndExpectResult(t *testing.T, query, expectedResult string) {
 	res, errs := parseQuery(query)
-	Equal(t, 0, len(errs))
-	Equal(t, formatHumanReadableQuery(expectedResult), string(res))
+	for _, err := range errs {
+		panic(err.Error())
+	}
+	Equal(t, formatHumanReadableQuery(expectedResult), formatResToHumandReadable(res))
 }
 
 func TestParseSimpleQuery(t *testing.T) {
 	parseQueryAndExpectResult(t, `{}`, `
 		oq // [operator] [query]
 		e  // [end of operator]
+	`)
+}
+
+func TestParseSimpleQueryWrittenOut(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {}`, `
+		oq // operator of type query
+		e  // end of operator
+	`)
+}
+
+func TestParseSimpleMutation(t *testing.T) {
+	parseQueryAndExpectResult(t, `mutation {}`, `
+		om // operator of type mutation
+		e  // end of operator
+	`)
+}
+
+func TestParseSimpleSubscription(t *testing.T) {
+	parseQueryAndExpectResult(t, `subscription {}`, `
+		os // operator of type subscription
+		e  // end of operator
+	`)
+}
+
+func TestParseQueryWithName(t *testing.T) {
+	parseQueryAndExpectResult(t, `query banana {}`, `
+		oqbanana // operator of type query with name banana
+		e        // end of operator
+	`)
+}
+
+func TestParseQueryWithField(t *testing.T) {
+	parseQueryAndExpectResult(t, `query {
+		some_field
+	}`, `
+		oq          // query operator
+		fsome_field // field with name some_field
+		e           // end field
+		e           // end operator
 	`)
 }

--- a/bytecode/bytecode_test.go
+++ b/bytecode/bytecode_test.go
@@ -146,7 +146,8 @@ func TestParseQueryWithField(t *testing.T) {
 	}`, `
 		oqf          // query operator
 		// No directives
-		fsome_field // field with name some_field
+		f           // start new field
+		some_field  // field name
 		// no field alias
 		e           // end field
 		e           // end operator
@@ -157,10 +158,12 @@ func TestParseQueryWithMultipleFields(t *testing.T) {
 	expectedOutput := `
 		oqf          // query operator
 		// No directives
-		fsome_field // field with name some_field
+		f           // start new field
+		some_field  // field name
 		// no field alias
 		e           // end field with name some_field
-		fother      // field with name other
+		f           // start new field
+		other       // field name
 		// no field alias
 		e           // end field with name other
 		e           // end operator
@@ -191,12 +194,15 @@ func TestParseQueryWithFieldWithSelectionSet(t *testing.T) {
 	}`, `
 		oqf          // query operator
 		// No directives
-		fsome_field // field with name some_field
+		f           // new field
+		some_field  // field name
 		// no field alias
-		ffoo        // field with name foo
+		f           // new field
+		foo         // field name
 		// no field alias
 		e           // end of foo
-		fbar        // field with name bar
+		f           // new field
+		bar         // field name
 		// no field alias
 		e           // end of bar
 		e           // end of some_field
@@ -214,13 +220,16 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 	}`, `
 		oqf
 		// No directives
-		fsome_field
+		f
+		some_field
 		// no field alias
-		ffoo
+		f
+		foo
 		// no field alias
 		e
 		sfbaz // fragment spread pointing to fragment with name baz
-		fbar
+		f
+		bar
 		// no field alias
 		e
 		e
@@ -237,13 +246,16 @@ func TestParseQueryWithFieldWithFragmentSpread(t *testing.T) {
 	}`, `
 		oqf
 		// No directives
-		fsome_field
+		f
+		some_field
 		// no field alias
-		ffoo
+		f
+		foo
 		// no field alias
 		e
 		sfonline // fragment spread pointing to fragment with name online
-		fbar
+		f
+		bar
 		// no field alias
 		e
 		e
@@ -255,17 +267,21 @@ func TestParseQueryWithFieldWithInlineFragmentSpread(t *testing.T) {
 	expectedOutput := `
 		oqf
 		// No directives
-		fsome_field
+		f
+		some_field
 		// no field alias
-		ffoo
+		f
+		foo
 		// no field alias
 		e
 		stbaz     // fragment spread with typename baz
-		fbazField // fragment field
+		f
+		bazField // fragment field
 		// no field alias
 		e         // end of fragment field
 		e         // end of inline fragment
-		fbar
+		f
+		bar
 		// no field alias
 		e
 		e
@@ -299,7 +315,8 @@ func TestParseAlias(t *testing.T) {
 	}`, `
 		oqf
 		// No directives
-		ffoo // field with alias foo
+		f
+		foo // field with alias foo
 		baz  // field name
 		e    // end of field
 		e
@@ -312,7 +329,8 @@ func TestParseArgumentsWithoutInput(t *testing.T) {
 	}`, `
 		oqf
 		// No directives
-		fbaz // field with alias foo
+		f
+		baz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)
 		e    // end of value object / arguments
@@ -348,7 +366,8 @@ func TestParseArgumentValueTypes(t *testing.T) {
 		parseQueryAndExpectResult(t, `query {baz(foo: `+option.input+`)}`, `
 			oqf
 			// No directives
-			fbaz // field with alias foo
+			f
+			baz  // field with alias foo
 			// no alias
 			vo   // value of kind object (these are the arguments)
 			ufoo // key foo
@@ -364,7 +383,8 @@ func TestParseMultipleArguments(t *testing.T) {
 	expect := `
 		oqf
 		// No directives
-		fbaz // field with alias foo
+		f
+		baz // field with alias foo
 		// no alias
 		vo   // value of kind object (these are the arguments)
 		ufoo // key foo
@@ -396,10 +416,12 @@ func TestParseFragmentWithFields(t *testing.T) {
 	}`, `
 		FFoo    // fragment with name Foo
 		Bar     // fragment type name
-		ffieldA
+		f
+		fieldA
 		// no field alias
 		e
-		fbField
+		f
+		bField
 		// no field alias
 		e
 		e       // end of fragment

--- a/query_parser_test.go
+++ b/query_parser_test.go
@@ -662,9 +662,7 @@ func TestQueryParserFieldDirectiveWithArguments(t *testing.T) {
 	}
 }
 
-// test if:
-// - parser doesn't panic on wired inputs
-// - parser doesn't hang on certain inputs
+// tests if parser doesn't panic nor hangs on wired inputs
 func injectCodeSurviveTest(baseQuery string, extraChars ...string) {
 	toTest := [][]string{
 		{"", "_", "-", "0"},


### PR DESCRIPTION
TODO:
- [x] Operator
  - [x] Operation Type (query, mutation, subscription)
  - [x] Name
  - [x] Variable Definitions
  - [x] Directives
  - [x] Selection Set
- [x] Field
  - [x] Name
  - [x] Alias
  - [x] Selection Set
  - [x] Directives
  - [x] Arguments
- [x] Selection Set
  - [x] Field
  - [x] Fragment reference
  - [x] Inline fragment
- [x] Fragments
  - [x] Inline
    - [x] Type Condition
    - [x] Directives
    - [x] SelectionSet
  - [x] Name defined fragment
    - [x] Fragment Name
    - [x] Type Condition
    - [x] Directives
    - [x] SelectionSet
- [x] Input values
  - [x] Variable *($some_var)*
  - [x] Int *(-500)*
  - [x] Float *(5.4234)*
  - [x] String
    - [x] Normal *("string text here")*
    - [x] Blok string *("""string text here""")*
  - [x] Boolean *(true / false)*
  - [x] Null *(null)*
  - [x] Enum *(SOME_ENUM_VALUE)*
  - [x] List *(["a", "b", "c"])*
  - [x] Object *({a: 1, b: 2, c: 3})*

*~~Note that this might never get into the main branch if the performance is worse than the current solution~~*
*From early testing the performance seems to be at least 2 times faster than the previous solution*